### PR TITLE
Support node v16+ and hapi v20+, update deps, test ESM usage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,3 @@
 import:
-  - source: hapipal/ci-config-travis:node_js.yml@hapi-v21
-  - source: hapipal/ci-config-travis:hapi_all.yml@hapi-v21
+  - source: hapipal/ci-config-travis:node_js.yml@node-v16-min
+  - source: hapipal/ci-config-travis:hapi_all.yml@node-v16-min

--- a/API.md
+++ b/API.md
@@ -4,7 +4,7 @@ Utilities for treating hapi plugins as standalone libraries.
 
 > **Note**
 >
-> Ahem is intended for use with hapi v19+ and nodejs v12+ (_see v1 for lower support_).  Ensure you've installed @hapi/hapi within your project.
+> Ahem is intended for use with hapi v20+ and nodejs v16+ (_see v2 for lower support_).  Ensure you've installed @hapi/hapi within your project.
 
 ## `Ahem`
 ### `await Ahem.instance([server], plugin, [options, [compose]])`

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2019-2022 Devin Ivy
+Copyright (c) 2019-2023 Devin Ivy
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of
 this software and associated documentation files (the "Software"), to deal in

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ npm install @hapipal/ahem
 ## Usage
 > See also the [API Reference](API.md)
 >
-> Ahem is intended for use with hapi v19+ and nodejs v12+ (_see v1 for lower support_).  Ensure you've installed @hapi/hapi within your project.
+> Ahem is intended for use with hapi v20+ and nodejs v16+ (_see v2 for lower support_).  Ensure you've installed @hapi/hapi within your project.
 
 Ahem's purpose is to encourage new possibilites for hapi plugin composition and portability.  It's a small tool that offers only subtly different functionality from [glue](https://github.com/hapijs/glue); but unlike glue, ahem's API is designed to strongly reinforce the perspective of hapi plugins as being instantiable general-purpose libraries, and not just web servers.
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const Assert = require('assert');
+const Assert = require('node:assert');
 const Hapi = require('@hapi/hapi');
 const Package = require('../package.json');
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,7 +1,7 @@
 'use strict';
 
+const Assert = require('assert');
 const Hapi = require('@hapi/hapi');
-const Hoek = require('@hapi/hoek');
 const Package = require('../package.json');
 
 const internals = {};
@@ -10,7 +10,7 @@ exports.plugin = {
     pkg: Package,
     once: true,
     requirements: {
-        hapi: '>=19'
+        hapi: '>=20'
     },
     register(server) {
 
@@ -57,8 +57,8 @@ exports.instance = async (server, plugin, options, compose) => {
 
     const { plugins, options: pluginOptions } = (register && !register.plugins) ? { plugins: register } : (register || {});
 
-    Hoek.assert(server || !controlled, 'A server must be specified when compose.controlled is true.');
-    Hoek.assert(!srvOptions || (controlled || !server), 'When a server is specified but compose.controlled is false, compose.server options are not allowed, as a new server will not be created.');
+    Assert.ok(server || !controlled, 'A server must be specified when compose.controlled is true.');
+    Assert.ok(!srvOptions || (controlled || !server), 'When a server is specified but compose.controlled is false, compose.server options are not allowed, as a new server will not be created.');
 
     const srv = (!controlled && server) ? server : Hapi.server(srvOptions);
 
@@ -90,8 +90,8 @@ exports.instance = async (server, plugin, options, compose) => {
 
     if (decorateRoot) {
 
-        Hoek.assert(!srv.realm.parent, 'Cannot use compose.decorateRoot option without access to a root server.');
-        Hoek.assert(!srv.decorations.server.includes('root') || srv.root === srv, 'Cannot use compose.decorateRoot on a server that already has a different root decoration.');
+        Assert.ok(!srv.realm.parent, 'Cannot use compose.decorateRoot option without access to a root server.');
+        Assert.ok(!srv.decorations.server.includes('root') || srv.root === srv, 'Cannot use compose.decorateRoot on a server that already has a different root decoration.');
 
         if (!srv.root) {
             srv.decorate('server', 'root', srv);
@@ -100,8 +100,8 @@ exports.instance = async (server, plugin, options, compose) => {
 
     if (decorateController) {
 
-        Hoek.assert(controlled, 'Cannot use compose.decorateController option when the instance is not controlled.');
-        Hoek.assert(!srv.decorations.server.includes('controller'), 'Cannot use compose.decorateController on a server that already has a controller decoration.');
+        Assert.ok(controlled, 'Cannot use compose.decorateController option when the instance is not controlled.');
+        Assert.ok(!srv.decorations.server.includes('controller'), 'Cannot use compose.decorateController on a server that already has a controller decoration.');
 
         srv.decorate('server', 'controller', server);
     }

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "hapi plugins as libraries",
   "main": "lib/index.js",
   "engines": {
-    "node": ">=12"
+    "node": ">=16"
   },
   "directories": {
     "test": "test"
@@ -36,15 +36,15 @@
   },
   "homepage": "https://github.com/hapipal/ahem#readme",
   "dependencies": {
-    "@hapi/hoek": "^9.0.0"
+    "@hapi/hoek": "^11.0.2"
   },
   "peerDependencies": {
-    "@hapi/hapi": ">=19 <22"
+    "@hapi/hapi": ">=20 <22"
   },
   "devDependencies": {
-    "@hapi/code": "^8.0.0",
-    "@hapi/hapi": "^20.0.0",
-    "@hapi/lab": "^24.0.0",
-    "coveralls": "^3.0.0"
+    "@hapi/code": "^9.0.3",
+    "@hapi/hapi": "^21.3.0",
+    "@hapi/lab": "^25.1.2",
+    "coveralls": "^3.1.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -35,9 +35,6 @@
     "url": "https://github.com/hapipal/ahem/issues"
   },
   "homepage": "https://github.com/hapipal/ahem#readme",
-  "dependencies": {
-    "@hapi/hoek": "^11.0.2"
-  },
   "peerDependencies": {
     "@hapi/hapi": ">=20 <22"
   },

--- a/test/esm.js
+++ b/test/esm.js
@@ -1,0 +1,29 @@
+'use strict';
+
+const Code = require('@hapi/code');
+const Lab = require('@hapi/lab');
+
+
+const { before, describe, it } = exports.lab = Lab.script();
+const expect = Code.expect;
+
+
+describe('import()', () => {
+
+    let Ahem;
+
+    before(async () => {
+
+        Ahem = await import('../lib/index.js');
+    });
+
+    it('exposes all methods and classes as named imports', () => {
+
+        expect(Object.keys(Ahem)).to.equal([
+            'default',
+            'instance',
+            'plugin',
+            'toFactory'
+        ]);
+    });
+});


### PR DESCRIPTION
Update dependencies, drop support for hapi v19, node v12, node v14.  Add tests for ESM usage.  Official support now is node v16+ and hapi v20+.